### PR TITLE
Filter and mangle keys in list

### DIFF
--- a/custodia/ipa/vault.py
+++ b/custodia/ipa/vault.py
@@ -112,7 +112,10 @@ class IPAVault(CSStore):
         names = []
         for entry in result[u'result']:
             cn = entry[u'cn'][0]
-            names.append(cn)
+            key = cn.replace('__', '/')
+            if keyfilter is not None and not key.startswith(keyfilter):
+                continue
+            names.append(key.rsplit('/', 1)[-1])
         return names
 
     def cut(self, key):


### PR DESCRIPTION
List did not apply the keyfilter and returned the full path instead just
the last path segment.

Signed-off-by: Christian Heimes <cheimes@redhat.com>