### PR TITLE
Retrieve and cache KRA transport cert

### DIFF
--- a/custodia/ipa/vault.py
+++ b/custodia/ipa/vault.py
@@ -93,6 +93,10 @@ class IPAVault(CSStore):
             self.principal = self.principal.decode('utf-8')
         with self.ipa:
             self.logger.info(repr(self.ipa.Command.ping()))
+            # retrieve and cache KRA transport cert
+            response = self.ipa.Command.vaultconfig_show()
+            servers = response[u'result'][u'kra_server_server']
+            self.logger.info("KRA server(s) %s", ', '.join(servers))
 
     def _mangle_key(self, key):
         if '__' in key:

--- a/tests.py
+++ b/tests.py
@@ -26,6 +26,11 @@ class TestCustodiaIPA(unittest.TestCase):
         self.m_api = self.p_api.start()
         self.m_api.Backend = mock.Mock()
         self.m_api.Command = mock.Mock()
+        self.m_api.Command.vaultconfig_show.return_value = {
+            u'result': {
+                u'kra_server_server': [u'ipa.example'],
+            }
+        }
 
     def tearDown(self):
         self.p_api.stop()
@@ -37,7 +42,8 @@ class TestCustodiaIPA(unittest.TestCase):
         m_api.isdone.assert_called_once_with('bootstrap')
         m_api.bootstrap.assert_called_once_with(
             context='cli',
-            debug=False
+            debug=False,
+            log=None,
         )
 
         m_api.Backend.rpcclient.isconnected.return_value = False


### PR DESCRIPTION
Starting with FreeIPA 4.5, vaultconfig_show caches the KRA transport
cert on disk.

Closes: #7 
Signed-off-by: Christian Heimes <cheimes@redhat.com>