### PR TITLE
Require custodia >= 0.3

### DIFF
--- a/README
+++ b/README
@@ -11,8 +11,10 @@ Requirements
 Runtime
 ~~~~~~~
 
--  custodia >= 0.2
+-  custodia >= 0.3
 -  ipalib >= 4.4
+-  ipaclient >= 4.4
+-  setuptools
 
 Installation and testing
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@
 
 ### Runtime
 
-* custodia >= 0.2
+* custodia >= 0.3
 * ipalib >= 4.4
+* ipaclient >= 4.4
+* setuptools
 
 ### Installation and testing
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 from setuptools import setup
 
 requirements = [
-    'custodia >= 0.2',
+    'custodia >= 0.3',
     'ipalib',
     'ipaclient',
 ]


### PR DESCRIPTION
Custodia 0.2 is missing some fixes.

Signed-off-by: Christian Heimes <cheimes@redhat.com>