### PR TITLE
Document and add workaround for FreeIPA 4.4 support

### DIFF
--- a/README
+++ b/README
@@ -181,10 +181,11 @@ Run Custodia server
 IPA cert request
 ----------------
 
-The IPACertRequest store plugin generates or revokes certificates on the
-fly. It uses a backing store to cache certs and private keys. The plugin
-can create service principal automatically. However the host must
-already exist.
+The *IPACertRequest* store plugin generates or revokes certificates on
+the fly. It uses a backing store to cache certs and private keys. The
+plugin can create service principal automatically. However the host must
+already exist. The *IPACertRequest* does not create host entries on the
+fly.
 
 The request ``GET /secrets/certs/HTTP/client1.ipa.example`` generates a
 private key and CSR for the service ``HTTP/client1.ipa.example`` with
@@ -194,3 +195,16 @@ the same time.
 
 Automatical renewal of revoked or expired certificates is not
 implemented yet.
+
+FreeIPA 4.4 support
+~~~~~~~~~~~~~~~~~~~
+
+The default settings and permissions are tuned for FreeIPA >= 4.5. For
+4.4, the plugin must be configured with ``chain=False``. The additional
+permission ``Request Certificate with SubjectAltName`` is required, too.
+
+::
+
+    ipa privilege-add-permission \
+        --permissions="Request Certificate with SubjectAltName" \
+        "Custodia Service Certs"

--- a/README.md
+++ b/README.md
@@ -170,9 +170,10 @@ $ custodia /etc/custodia/custodia.conf
 
 ## IPA cert request
 
-The IPACertRequest store plugin generates or revokes certificates on the
+The *IPACertRequest* store plugin generates or revokes certificates on the
 fly. It uses a backing store to cache certs and private keys. The plugin can
 create service principal automatically. However the host must already exist.
+The *IPACertRequest* does not create host entries on the fly. 
 
 The request ```GET /secrets/certs/HTTP/client1.ipa.example``` generates a
 private key and CSR for the service ```HTTP/client1.ipa.example``` with
@@ -182,3 +183,14 @@ the same time.
 
 Automatical renewal of revoked or expired certificates is not implemented yet.
 
+### FreeIPA 4.4 support
+
+The default settings and permissions are tuned for FreeIPA >= 4.5. For 4.4,
+the plugin must be configured with ```chain=False```. The additional
+permission ```Request Certificate with SubjectAltName``` is required, too.
+
+```
+ipa privilege-add-permission \
+    --permissions="Request Certificate with SubjectAltName" \
+    "Custodia Service Certs"
+```

--- a/src/custodia/ipa/certrequest.py
+++ b/src/custodia/ipa/certrequest.py
@@ -152,13 +152,15 @@ class _ServerCSRGenerator(_CSRGenerator):
 
     # pylint: disable=arguments-differ
     def _cert_request(self, pem_req, principal, **kwargs):
+        # FreeIPA 4.4 has no chain option, only pass kwarg when enabled
+        if self.plugin.chain:
+            kwargs['chain'] = True
         with self.plugin.ipa as ipa:
             return ipa.Command.cert_request(
                 pem_req,
                 profile_id=self.plugin.cert_profile,
                 add=self.plugin.add_principal,
                 principal=principal,
-                chain=self.plugin.chain,
                 **kwargs
             )
 


### PR DESCRIPTION
FreeIPA 4.4 needs additional permission "Request Certificate with
SubjectAltName" and does not support the chain argument.

Signed-off-by: Christian Heimes <cheimes@redhat.com>