### PR TITLE
Update README and config for Custodia 0.5

### DIFF
--- a/README
+++ b/README
@@ -27,7 +27,7 @@ Installation
 Runtime
 ~~~~~~~
 
--  custodia >= 0.4.0
+-  custodia >= 0.5.0
 -  ipalib >= 4.5.0
 -  ipaclient >= 4.5.0
 -  Python 2.7 (Python 3 support in IPA vault is unstable.)
@@ -93,10 +93,11 @@ Create service account and keytab
 ::
 
     $ kinit admin
-    $ ipa service-add custodia/client1.ipa.example
-    $ ipa service-allow-create-keytab custodia/client1.ipa.example --users=admin
+    $ ipa service-add custodia/$HOSTNAME
+    $ ipa service-allow-create-keytab custodia/$HOSTNAME --users=admin
     $ mkdir -p /etc/custodia
-    $ ipa-getkeytab -p custodia/client1.ipa.example -k /etc/custodia/custodia.keytab
+    $ ipa-getkeytab -p custodia/$HOSTNAME -k /etc/custodia/ipa.keytab
+    $ chown custodia:custodia /etc/custodia/ipa.keytab
 
 The IPA cert request plugin needs additional permissions
 
@@ -122,27 +123,22 @@ The IPA cert request plugin needs additional permissions
         --privileges="Custodia Service Certs" \
         "Custodia Service Cert Adminstrator"
     $ ipa role-add-member \
-        --services="custodia/client1.ipa.example" \
+        --services="custodia/$HOSTNAME" \
         "Custodia Service Cert Adminstrator"
 
-Create ``/etc/custodia/custodia.conf``
+Create ``/etc/custodia/ipa.conf``
 
 ::
 
-    [DEFAULT]
-    confdir = /etc/custodia
-    libdir = /var/lib/custodia
-    logdir = /var/log/custodia
-    rundir = /var/run/custodia
+    # /etc/custodia/ipa.conf
 
     [global]
     debug = true
-    server_socket = ${rundir}/custodia.sock
-    auditlog = ${logdir}/audit.log
+    makedirs = true
 
     [auth:ipa]
     handler = IPAInterface
-    keytab = ${confdir}/custodia.keytab
+    keytab = ${configdir}/${instance}.keytab
     ccache = FILE:${rundir}/ccache
 
     [auth:creds]
@@ -176,7 +172,7 @@ Run Custodia server
 
 ::
 
-    $ custodia /etc/custodia/custodia.conf
+    $ systemctl start custodia@ipa.socket
 
 IPA cert request
 ----------------
@@ -195,6 +191,7 @@ chain is returned together with the private key as a PEM bundle.
 
 ::
 
+    $ export CUSTODIA_INSTANCE=ipa
     $ custodia-cli get /certs/HTTP/client1.ipa.example
     -----BEGIN RSA PRIVATE KEY-----
     ...

--- a/contrib/config/ipa.conf
+++ b/contrib/config/ipa.conf
@@ -1,19 +1,12 @@
-# /etc/custodia/custodia.conf
-
-[DEFAULT]
-confdir = /etc/custodia
-libdir = /var/lib/custodia
-logdir = /var/log/custodia
-rundir = /var/run/custodia
+# /etc/custodia/ipa.conf
 
 [global]
 debug = true
-server_socket = ${rundir}/custodia.sock
-auditlog = ${logdir}/audit.log
+makedirs = true
 
 [auth:ipa]
 handler = IPAInterface
-keytab = ${confdir}/custodia.keytab
+keytab = ${configdir}/${instance}.keytab
 ccache = FILE:${rundir}/ccache
 
 [auth:creds]
@@ -42,3 +35,4 @@ store = vault
 [/secrets/certs]
 handler = Secrets
 store = cert
+


### PR DESCRIPTION
The README now uses new Custodia 0.5 features like named instance and
default settings for directories.

Signed-off-by: Christian Heimes <cheimes@redhat.com>