### PR TITLE
Coverage: combine and only report custodia.ipa

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,13 +1,13 @@
 [run]
 branch = True
 source =
-    custodia
+    custodia.ipa
     tests
 
 [paths]
 source =
-   src/custodia
-   .tox/*/lib/python*/site-packages/custodia
+   src/custodia/ipa
+   .tox/*/lib/python*/site-packages/custodia/ipa
 
 [report]
 ignore_errors = False

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,15 @@ before_install:
   - sudo apt-get install -y python-pip python-virtualenv python-dev gcc krb5-user libkrb5-dev libffi-dev libnss3-dev libldap2-dev libsasl2-dev libssl-dev
 
 install:
-  - pip install --upgrade pip setuptools
+  - pip install --upgrade pip
+  - pip install --upgrade setuptools
   - pip --version
-  - pip install tox
+  - pip install --upgrade codecov tox
   - tox --version
 
 script:
   - tox -v
+
+after_success:
+  - python -m coverage combine
+  - codecov

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.3.1
-envlist = lint,py27,py34,py35,py36,pep8py2,pep8py3,doc
+envlist = lint,py27,py34,py35,py36,pep8py2,pep8py3,doc,coverage-report
 skip_missing_interpreters = true
 
 [testenv]
@@ -9,9 +9,15 @@ deps =
 # Makefile and RPM spec set sitepackages=True
 sitepackages = False
 commands =
-    {envpython} -m coverage run --append \
+    {envpython} -m coverage run --parallel \
         -m pytest --capture=no --strict {posargs}
-    {envpython} -m coverage report -m
+
+[testenv:coverage-report]
+deps = coverage
+skip_install = true
+commands =
+    {envpython} -m coverage combine
+    {envpython} -m coverage report
 
 [testenv:lint]
 basepython = python2.7


### PR DESCRIPTION
Use the same parallel coverage configuration as custodia and only report
coverage for custodia.ipa modules.

Signed-off-by: Christian Heimes <cheimes@redhat.com>