### PR TITLE
Fix retrival of IPAInterface

### DIFF
--- a/src/custodia/ipa/certrequest.py
+++ b/src/custodia/ipa/certrequest.py
@@ -24,7 +24,7 @@ import six
 from custodia.plugin import CSStore, PluginOption, REQUIRED
 from custodia.plugin import CSStoreDenied, CSStoreError
 
-from .interface import IPA_SECTIONNAME
+from .interface import IPAInterface
 
 
 TLS_SERVERAUTH = oid.ObjectIdentifier('2.5.29.37.1')
@@ -200,7 +200,9 @@ class IPACertRequest(CSStore):
 
     def finalize_init(self, config, cfgparser, context=None):
         super(IPACertRequest, self).finalize_init(config, cfgparser, context)
-        self.ipa = config['authorizers'][IPA_SECTIONNAME]
+        if self.ipa is not None:
+            return
+        self.ipa = IPAInterface.from_config(config)
         self.ipa.finalize_init(config, cfgparser, context=self)
 
     def _parse_key(self, key):
@@ -311,7 +313,7 @@ class IPACertRequest(CSStore):
 def test():
     from custodia.compat import configparser
     from custodia.log import setup_logging
-    from .interface import IPAInterface
+    from .interface import IPA_SECTIONNAME
     from .vault import IPAVault
 
     parser = configparser.ConfigParser(
@@ -329,8 +331,8 @@ def test():
 
     setup_logging(debug=True, auditfile=None)
     config = {
-        'authorizers': {
-            IPA_SECTIONNAME: IPAInterface(parser, IPA_SECTIONNAME)
+        'authenticators': {
+            'ipa': IPAInterface(parser, IPA_SECTIONNAME)
         }
     }
     vault = IPAVault(parser, 'store:ipa_vault')

--- a/src/custodia/ipa/interface.py
+++ b/src/custodia/ipa/interface.py
@@ -60,6 +60,10 @@ class IPAInterface(HTTPAuthenticator):
         if self.ipa_confdir is not None:
             self._ipa_config['confdir'] = self.ipa_confdir
 
+    @classmethod
+    def from_config(cls, config):
+        return config['authenticators']['ipa']
+
     def finalize_init(self, config, cfgparser, context=None):
         super(IPAInterface, self).finalize_init(config, cfgparser, context)
 

--- a/src/custodia/ipa/vault.py
+++ b/src/custodia/ipa/vault.py
@@ -12,7 +12,7 @@ from custodia.plugin import (
     CSStoreDenied, CSStoreError, CSStoreExists, CSStoreUnsupported
 )
 
-from .interface import IPA_SECTIONNAME
+from .interface import IPAInterface
 
 
 def krb5_unparse_principal_name(name):
@@ -57,7 +57,10 @@ class IPAVault(CSStore):
 
     def finalize_init(self, config, cfgparser, context=None):
         super(IPAVault, self).finalize_init(config, cfgparser, context)
-        self.ipa = config['authorizers'][IPA_SECTIONNAME]
+
+        if self.ipa is not None:
+            return
+        self.ipa = IPAInterface.from_config(config)
         self.ipa.finalize_init(config, cfgparser, context=self)
 
         # connect
@@ -211,7 +214,7 @@ class IPAVault(CSStore):
 def test():
     from custodia.compat import configparser
     from custodia.log import setup_logging
-    from .interface import IPAInterface
+    from .interface import IPA_SECTIONNAME
 
     parser = configparser.ConfigParser(
         interpolation=configparser.ExtendedInterpolation()
@@ -225,8 +228,8 @@ def test():
 
     setup_logging(debug=True, auditfile=None)
     config = {
-        'authorizers': {
-            IPA_SECTIONNAME: IPAInterface(parser, IPA_SECTIONNAME)
+        'authenticators': {
+            'ipa': IPAInterface(parser, IPA_SECTIONNAME)
         }
     }
     v = IPAVault(parser, 'store:ipa_vault')

--- a/tests.py
+++ b/tests.py
@@ -181,7 +181,7 @@ class BaseTest(object):
         # config
         self.config = {
             'debug': False,
-            'authorizers': {},
+            'authenticators': {},
             'stores': {},
         }
         # mocked ipalib.api
@@ -226,8 +226,11 @@ class TestCustodiaIPA(BaseTest):
             IPA_SECTIONNAME,
             api=m_api
         )
-        self.config['authorizers'][IPA_SECTIONNAME] = ipa
+        self.config['authenticators']['ipa'] = ipa
         ipa.finalize_init(self.config, self.parser, None)
+        assert (self.config['authenticators']['ipa'] is
+                IPAInterface.from_config(self.config))
+
         m_api.isdone.assert_called_once_with('bootstrap')
         m_api.bootstrap.assert_called_once_with(
             context='cli',
@@ -257,8 +260,10 @@ class TestCustodiaIPAVault(BaseTest):
         self.m_get_principal.return_value = principal
 
         ipa = IPAInterface(self.parser, IPA_SECTIONNAME)
-        self.config['authorizers'][IPA_SECTIONNAME] = ipa
+        self.config['authenticators']['ipa'] = ipa
         ipa.finalize_init(self.config, self.parser, None)
+        assert (self.config['authenticators']['ipa'] is
+                IPAInterface.from_config(self.config))
 
         vault = IPAVault(self.parser, section)
         self.config['stores'][section] = vault
@@ -367,8 +372,10 @@ class TestCustodiaIPACertRequests(BaseTest):
         self.m_get_principal.return_value = principal
 
         ipa = IPAInterface(self.parser, IPA_SECTIONNAME)
-        self.config['authorizers'][IPA_SECTIONNAME] = ipa
+        self.config['authenticators']['ipa'] = ipa
         ipa.finalize_init(self.config, self.parser, None)
+        assert (self.config['authenticators']['ipa'] is
+                IPAInterface.from_config(self.config))
 
         certreq = IPACertRequest(self.parser, section)
         self.config['stores'][section] = certreq


### PR DESCRIPTION
The IPAInterface instance is in config['authenticators']['ipa'], not in
config['authorizers']['auth:ipa'].

Signed-off-by: Christian Heimes <cheimes@redhat.com>