### PR TITLE
Handle missing kra_server_server key

### DIFF
--- a/src/custodia/ipa/vault.py
+++ b/src/custodia/ipa/vault.py
@@ -67,8 +67,9 @@ class IPAVault(CSStore):
         with self.ipa:
             # retrieve and cache KRA transport cert
             response = self.ipa.Command.vaultconfig_show()
-            servers = response[u'result'][u'kra_server_server']
-            self.logger.info("KRA server(s) %s", ', '.join(servers))
+            servers = response[u'result'].get(u'kra_server_server', ())
+            if servers:
+                self.logger.info("KRA server(s) %s", ', '.join(servers))
 
         service, user_host, realm = krb5_unparse_principal_name(
             self.ipa.principal)


### PR DESCRIPTION
The vaultconfig_show plugin may return an empty list or no entry at all
for kra_server_server when the principal has no permission to read the
value from LDAP.

See https://bugzilla.redhat.com/show_bug.cgi?id=1462403

Signed-off-by: Christian Heimes <cheimes@redhat.com>